### PR TITLE
Add rockspec

### DIFF
--- a/love-imgui-scm-1.rockspec
+++ b/love-imgui-scm-1.rockspec
@@ -1,0 +1,28 @@
+package = "love-imgui"
+version = "scm-1"
+source = {
+	url = "git://github.com/slages/love-imgui.git"
+}
+description = {
+	summary = "imgui module for the LOVE game engine",
+	detailed = [[
+dear imgui (AKA ImGui), is a bloat-free graphical user interface library for
+C++. ImGui is particularly suited to integration in realtime 3D applications,
+fullscreen applications, embedded applications, games, or any applications on
+platforms where operating system features are non-standard. This library embeds
+ImGui in way that is suitable for use with the LOVE game engine.
+]],
+	homepage = "https://github.com/slages/love-imgui",
+	license = "MIT"
+}
+dependencies = {
+	"lua ~> 5.1",
+	"love ~> 0.10"
+}
+build = {
+	type = "cmake",
+	variables = {
+		LUAJIT_INCLUDE_DIR="$(LUA_INCDIR)",
+		LIB_DIR="$(LIBDIR)"
+	}
+}

--- a/rockspecs/love-imgui-0.7-1.rockspec
+++ b/rockspecs/love-imgui-0.7-1.rockspec
@@ -1,3 +1,31 @@
+package = "love-imgui"
+version = "0.7-1"
+source = {
+   url = "git://github.com/slages/love-imgui.git"
+}
+description = {
+   summary = "imgui module for the LOVE game engine",
+   detailed = [[
+dear imgui (AKA ImGui), is a bloat-free graphical user interface library for
+C++. ImGui is particularly suited to integration in realtime 3D applications,
+fullscreen applications, embedded applications, games, or any applications on
+platforms where operating system features are non-standard. This library embeds
+ImGui in way that is suitable for use with the LOVE game engine.
+]],
+   homepage = "https://github.com/slages/love-imgui",
+   license = "MIT"
+}
+dependencies = {
+   "lua ~> 5.1",
+   "love ~> 0.10"
+}
+build = {
+   type = "cmake",
+   variables = {
+      LIB_DIR = "$(LIBDIR)",
+      LUAJIT_INCLUDE_DIR = "$(LUA_INCDIR)"
+   },
+   cmake = [=[
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
 SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
@@ -40,3 +68,5 @@ SET_TARGET_PROPERTIES(${LIB_NAME} PROPERTIES PREFIX "")
 IF(DEFINED "LIB_DIR")
 	INSTALL(TARGETS ${LIB_NAME} LIBRARY DESTINATION ${LIB_DIR})
 ENDIF()
+]=]
+}


### PR DESCRIPTION
This change packages love-imgui for use with [loverocks](https://github.com/Alloyed/loverocks). This means (assuming you upload the rockspec to luarocks.org) that users that want to install imgui can just type
```
$ loverocks install love-imgui
```
to get the latest stable imgui, and people can write apps/packages that depend on imgui and have it resolve automatically.

To upload to luarocks.org, you should [sign up](https://luarocks.org/register) and then get an [API key](https://luarocks.org/settings/api-keys). Then you can just do:
```
$ luarocks upload --api-key<your key> love-imgui-scm-1.rockspec
$ luarocks upload rockspecs/love-imgui-0.7-1.rockspec
```