### PR TITLE
Fix bug in config saving

### DIFF
--- a/src/imgui_impl.cpp
+++ b/src/imgui_impl.cpp
@@ -187,7 +187,7 @@ bool Init(lua_State *L)
 
 	io.Fonts->TexID = NULL;
 
-	luaL_dostring(L, "love.filesystem.createDirectory(love.filesystem.getSaveDirectory()) return love.filesystem.getSaveDirectory()");
+	luaL_dostring(L, "love.filesystem.createDirectory('/') return love.filesystem.getSaveDirectory()");
 	const char *path = luaL_checkstring(L, 1);
 	g_iniPath = std::string(path) + std::string("/imgui.ini");
 	io.IniFilename = g_iniPath.c_str();


### PR DESCRIPTION
love-imgui had the unintended effect of creating the save directory's
path _inside_ the save directory, e.g.

    /home/kyle/.local/share/mygame/home/kyle/.local/share/mygame

The createDir call is still necessary so that the folder exists when
imgui tries to write to it, but now it creates the correct path.