### PR TITLE
Custom binding for setting global font

### DIFF
--- a/src/imgui_impl.cpp
+++ b/src/imgui_impl.cpp
@@ -351,3 +351,15 @@ bool GetWantTextInput()
 	ImGuiIO& io = ImGui::GetIO();
 	return io.WantTextInput;
 }
+
+// Fonts
+void SetGlobalFontFromFileTTF(const char *path, float size_pixels, float spacing_x, float spacing_y, float oversample_x, float oversample_y)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    ImFontConfig conf;
+    conf.OversampleH = oversample_x;
+    conf.OversampleV = oversample_y;
+    conf.GlyphExtraSpacing.x = spacing_x;
+    conf.GlyphExtraSpacing.y = spacing_y;
+    io.Fonts->AddFontFromFileTTF(path, size_pixels, &conf);
+}

--- a/src/imgui_impl.h
+++ b/src/imgui_impl.h
@@ -21,3 +21,6 @@ void TextInput(const char *text);
 bool GetWantCaptureMouse();
 bool GetWantCaptureKeyboard();
 bool GetWantTextInput();
+// Fonts
+void SetGlobalFontFromFileTTF(const char *path, float size_pixels,
+        float spacing_x, float spacing_y, float oversample_x, float oversample_y);

--- a/src/wrap_imgui_impl.cpp
+++ b/src/wrap_imgui_impl.cpp
@@ -139,6 +139,39 @@ static int w_GetStyleColCount(lua_State *L)
 	return 1;
 }
 
+static int w_SetGlobalFontFromFileTTF(lua_State *L)
+{
+    size_t size;
+    const char *path = luaL_checklstring(L, 1, &size);
+    float size_pixels = luaL_checknumber(L, 2);
+    float spacing_x = luaL_optnumber(L, 3, 0);
+    float spacing_y = luaL_optnumber(L, 4, 0);
+    float oversample_x = luaL_optnumber(L, 5, 1);
+    float oversample_y = luaL_optnumber(L, 6, 1);
+
+    lua_getglobal(L, "love");
+    lua_getfield(L, -1, "filesystem");
+    lua_remove(L, -2);
+    lua_getfield(L, -1, "getRealDirectory");
+    lua_remove(L, -2);
+    lua_pushstring(L, path);
+    lua_call(L, 1, 1);
+    if(lua_isnil(L, -1))
+    {
+        lua_pushstring(L, "File does not exist.");
+        lua_error(L);
+        return 0;
+    }
+    lua_pushstring(L, "/");
+    lua_pushstring(L, path);
+    lua_concat(L, 3);
+    const char *realpath = lua_tostring(L, -1);
+    lua_pop(L, 1);
+
+    SetGlobalFontFromFileTTF(realpath, size_pixels, spacing_x, spacing_y, oversample_x, oversample_y);
+    return 0;
+}
+
 /*
 ** Wrapped functions
 */
@@ -785,6 +818,7 @@ static const struct luaL_Reg imguilib[] = {
   // Custom
   { "GetStyleColName", w_GetStyleColName },
   { "GetStyleColCount", w_GetStyleColCount },
+  { "SetGlobalFontFromFileTTF", w_SetGlobalFontFromFileTTF },
 
   // Overrides
   { "Value", w_Value },


### PR DESCRIPTION
This is a quick-and-dirty way to change the font, without getting into making a Lua type for ImFont or anything like that. The Lua function signature is:

    imgui.SetGlobalFontFromFileTTF(path, size_pixels, spacing_x, spacing_y, oversample_x, oversample_y)
    
    string path
    number size_pixels
    number spacing_x (0)
    number spacing_y (0)
    number oversample_x (1)
    number oversample_y (1)

As the function name hopefully suggests, this should probably only be called in love.load.