### PR TITLE
Add: functionality to change default font to one of the preloaded fonts at runtime

### DIFF
--- a/src/imgui_iterator.h
+++ b/src/imgui_iterator.h
@@ -580,6 +580,12 @@ INT_ARG(column_index)
 NUMBER_ARG(width)
 CALL_FUNCTION_NO_RET(SetColumnWidth, column_index, width)
 END_IMGUI_FUNC
+//    IMGUI_API void          SetDefaultFontLua(const char* label, int font_id);		// hack
+IMGUI_FUNCTION(SetDefaultFontLua)
+LABEL_ARG(label)
+INT_ARG(font_id)
+CALL_FUNCTION_NO_RET(SetDefaultFontLua, label, font_id)
+END_IMGUI_FUNC
 //    IMGUI_API float         GetColumnOffset(int column_index = -1);                             // get position of column line (in pixels, from the left side of the contents region). pass -1 to use current column, otherwise 0..GetColumnsCount() inclusive. column 0 is typically 0.0f
 IMGUI_FUNCTION(GetColumnOffset)
 OPTIONAL_INT_ARG(column_index, -1)

--- a/src/libimgui/imgui.cpp
+++ b/src/libimgui/imgui.cpp
@@ -5265,6 +5265,17 @@ void ImGui::PushFont(ImFont* font)
     g.CurrentWindow->DrawList->PushTextureID(font->ContainerAtlas->TexID);
 }
 
+void ImGui::SetDefaultFontLua(const char* label, int font_id)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    ImFont* font_current = ImGui::GetFont();
+    for (int n = 0; n < io.Fonts->Fonts.Size; n++) {
+        if (n == font_id) {
+            io.FontDefault = io.Fonts->Fonts[n];
+        }
+    }
+}
+
 void  ImGui::PopFont()
 {
     ImGuiContext& g = *GImGui;

--- a/src/libimgui/imgui.h
+++ b/src/libimgui/imgui.h
@@ -192,6 +192,7 @@ namespace ImGui
 
     // Parameters stacks (shared)
     IMGUI_API void          PushFont(ImFont* font);                                             // use NULL as a shortcut to push default font
+    IMGUI_API void          SetDefaultFontLua(const char* label, int font_id);			// hack
     IMGUI_API void          PopFont();
     IMGUI_API void          PushStyleColor(ImGuiCol idx, ImU32 col);
     IMGUI_API void          PushStyleColor(ImGuiCol idx, const ImVec4& col);


### PR DESCRIPTION
As per title, this commit adds functionality to change default font to one of the preloaded fonts at runtime.

**Usage:** 
imgui.SetDefaultFontLua(".", fontIndex)

**pseudo code**
Here is a gist showing how I'm using it at the moment (excerpt from actual much longer main.lua):
https://gist.github.com/gdinit/92e29769954b28a25d2dbe067c1a03f2#file-main-lua-L112