### PR TITLE
Fix getting window size

### DIFF
--- a/src/imgui_impl.cpp
+++ b/src/imgui_impl.cpp
@@ -205,9 +205,9 @@ void NewFrame()
 
 	// Setup display size (every frame to accommodate for window resizing)
 	luaL_dostring(g_L, "return love.graphics.getWidth()");
-	float w = luaL_checknumber(g_L, 0);
+	float w = luaL_checknumber(g_L, -1);
 	luaL_dostring(g_L, "return love.graphics.getHeight()");
-	float h = luaL_checknumber(g_L, 0);
+	float h = luaL_checknumber(g_L, -1);
 	//int display_w, display_h;
 	// SDL_GL_GetDrawableSize(window, &display_w, &display_h);
 	io.DisplaySize = ImVec2(w, h);


### PR DESCRIPTION
At least for me (LOVE 11.4, LuaJIT 2.1.0-beta3), the basic repo does not work as is. If I take the sample code, there is no imgui window appearing.

Delving with `gdb`, I figured out that the window width and height at the start of `NewFrame` were always 0. I have very limited Lua FFI understand, as well as understanding of the stack. But I tried changing the float return to -1 (last value on the stack), and now the code works !

So, here is my PR. I have no idea if this is affecting others.